### PR TITLE
Fix build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,7 +204,7 @@ module.exports = function(grunt) {
       },
       scss: {
         files: ['css/**/*.scss'],
-        tasks: ['sass:dist'],
+        tasks: ['sass:dist']
       }
     },
 
@@ -261,7 +261,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-usemin');
 
   // Default
-  grunt.registerTask('default', ['connect', 'watch']);
+  grunt.registerTask('default', ['connect', 'sass', 'cssmin', 'watch']);
   grunt.registerTask('build', ['clean', 'jshint', 'sass', 'cssmin', 'uglify', 'templates', 'copy', 'rev', 'usemin', 'htmlmin', 'compress']);
 
 };


### PR DESCRIPTION
Initially build minified CSS before running the watch task for the first time.

If you start the default grunt task for the first time (without modifying any sass files at first), the local connect server can't serve any css. So make sure that the css is created initially before running the watch task.
