### PR TITLE
Typos and spelling

### DIFF
--- a/docs/actions.html
+++ b/docs/actions.html
@@ -86,10 +86,10 @@
 
 <p> Always make sure, you terminate it with the <a href="end">assertions.html#meth-end</a> method!</p><a class="nav-helper" data-name="meth-$"></a><h2 class="method"> .$</h2><p> Alias of query</p><a class="nav-helper" data-name="meth-toFrame"></a><h2 class="method"> .toFrame</h2><p> Switches to an iFrame context</p>
 
-<p> Sometimes you encounter situations, where you need to drive/access an iFrame sitting in your page.
- You can access such frames with this mehtod, but be aware of the fact, that the complete test context
- than switches to the iframe context, every action and assertion will be executed within the iFrame context.
- Btw.: The domain of the IFrame can be whatever you want, this method has no same origin policy restrictions.</p>
+<p> Sometimes you encounter situations, where you need to drive/access an iframe sitting in your page.
+ You can access such frames with this method, but be aware of the fact, that the complete test context
+ then switches to the iframe context, every action and assertion will be executed within the iframe context.
+ Btw.: The domain of the iframe can be whatever you want, this method has no same origin policy restrictions.</p>
 
 <p> If you wan&#39;t to get back to the parents context, you have to use the <a href="#meth-toParent">toParent</a> method.</p>
 


### PR DESCRIPTION
Use one spelling for iframe (i.e. "iframe", not "iFrame" or "IFrame").
